### PR TITLE
fixed indentaion error that was preventing correct md rendering

### DIFF
--- a/data-visualise.ipynb
+++ b/data-visualise.ipynb
@@ -708,7 +708,7 @@
     "    (ggplot(penguins, aes(x = species)) +\n",
     "      geom_bar(color = \"red\"))\n",
     "\n",
-    "   (ggplot(penguins, aes(x = species)) +\n",
+    "    (ggplot(penguins, aes(x = species)) +\n",
     "      geom_bar(fill = \"red\"))\n",
     "    ```\n",
     "\n",


### PR DESCRIPTION
The second function was not being rendered in the markdown code cell, fixing its indentation seems to fix it.